### PR TITLE
Fix LocalDataSource singleton initialization

### DIFF
--- a/app/src/main/java/com/aditya/watchit/data/source/local/LocalDataSource.kt
+++ b/app/src/main/java/com/aditya/watchit/data/source/local/LocalDataSource.kt
@@ -9,10 +9,13 @@ import com.aditya.watchit.data.source.local.room.FavoritDao
 
 class LocalDataSource private constructor(private val favoritDao: FavoritDao) {
     companion object {
+        @Volatile
         private var INSTANCE: LocalDataSource? = null
 
         fun getInstance(favoritDao: FavoritDao): LocalDataSource =
-            INSTANCE ?: LocalDataSource(favoritDao)
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: LocalDataSource(favoritDao).also { INSTANCE = it }
+            }
     }
 
     fun getAllPopular(): DataSource.Factory<Int, PopularEntity> = favoritDao.getPopularList()


### PR DESCRIPTION
## Summary
- fix LocalDataSource singleton initialization to avoid creating multiple instances

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6895a68df578833289c9117ae794b038